### PR TITLE
feat: fromJson can take an object as parameter

### DIFF
--- a/lib/classificator.js
+++ b/lib/classificator.js
@@ -21,30 +21,41 @@ const STATE_KEYS = (module.exports.STATE_KEYS = [
  * Initializes a NaiveBayes instance from a JSON state representation.
  * Use this with classifier.toJson().
  *
- * @param  {String} jsonStr   state representation obtained by classifier.toJson()
- * @return {NaiveBayes}       Classifier
+ * @param  {String|Object} jsonStrOrObject   state representation obtained by classifier.toJson()
+ * @return {NaiveBayes}                      Classifier
  */
-module.exports.fromJson = jsonStr => {
-  let parsed;
+module.exports.fromJson = jsonStrOrObject => {
+  let parameters;
 
   try {
-    parsed = JSON.parse(jsonStr);
+    switch (typeof jsonStrOrObject) {
+      case 'string':
+        parameters = JSON.parse(jsonStrOrObject);
+        break;
+
+      case 'object':
+        parameters = jsonStrOrObject;
+        break;
+
+      default:
+        throw new Error('');
+    }
   } catch (e) {
-    console.error(e);
-    throw new Error('Naivebayes.fromJson expects a valid JSON string.');
+    console.log(e);
+    throw new Error('Naivebays.fromJson expects a valid JSON string or an object.')
   }
 
   // init a new classifier
-  let classifier = new Naivebayes(parsed.options);
+  let classifier = new Naivebayes(parameters.options);
 
   // override the classifier's state
   STATE_KEYS.forEach(k => {
-    if (!parsed[k]) {
+    if (!parameters[k]) {
       throw new Error(
         `Naivebayes.fromJson: JSON string is missing an expected property: [${k}].`
       );
     }
-    classifier[k] = parsed[k];
+    classifier[k] = parameters[k];
   });
 
   return classifier;


### PR DESCRIPTION
This fixes #4.

In `bayes.fromJson`, we check if the parameter is an objet or a string. If it's a string we pass it to `JSON.parse`. If it's an objet we just use it.