### PR TITLE
feat: Add alpha parameter 🔧

### DIFF
--- a/lib/classificator.js
+++ b/lib/classificator.js
@@ -15,7 +15,9 @@ const STATE_KEYS = (module.exports.STATE_KEYS = [
   'wordCount',
   'wordFrequencyCount',
   'options',
+  'alpha',
 ]);
+const DEFAULT_ALPHA = 1
 
 /**
  * Initializes a NaiveBayes instance from a JSON state representation.
@@ -102,6 +104,7 @@ function Naivebayes(options) {
   }
 
   this.tokenizer = this.options.tokenizer || defaultTokenizer;
+  this.alpha = this.options.alpha || DEFAULT_ALPHA
 
   //initialize our vocabulary and its size
   this.vocabulary = {};
@@ -342,14 +345,13 @@ Naivebayes.prototype.categorize = function(text){
  */
 Naivebayes.prototype.tokenProbability = function(token, category){
   //how many times this word has occurred in documents mapped to this category
-  let wordFrequencyCount = this.wordFrequencyCount[category][token] || 0;
+  const wordFrequencyCount = this.wordFrequencyCount[category][token] || 0;
 
   //what is the count of all words that have ever been mapped to this category
-  let wordCount = this.wordCount[category];
-
+  const wordCount = this.wordCount[category];
 
   //use laplace Add-1 Smoothing equation
-  return (wordFrequencyCount + 1) / (wordCount + this.vocabularySize);
+  return (wordFrequencyCount + this.alpha) / (wordCount + this.vocabularySize);
 };
 
 /**

--- a/lib/classificator.js
+++ b/lib/classificator.js
@@ -351,7 +351,7 @@ Naivebayes.prototype.tokenProbability = function(token, category){
   const wordCount = this.wordCount[category];
 
   //use laplace Add-1 Smoothing equation
-  return (wordFrequencyCount + this.alpha) / (wordCount + this.vocabularySize);
+  return (wordFrequencyCount + this.alpha) / (wordCount + this.alpha * this.vocabularySize);
 };
 
 /**


### PR DESCRIPTION
Bonjour @Wozacosta ,

Voici une PR pour améliorer le paramétrage de la librairie.

Dans la fonction `tokenProbability`, il y a un [` + 1`](https://github.com/Wozacosta/classificator/blob/537cc6014822a9ac525a94c4529c2e6ac74b22dd/lib/classificator.js#L352). Il s'agit d'une variable mathématique utilisée pour améliorer l'estimation des paramètres du modèle (au sens mathématiques) et la valeur 1 n'est qu'une valeur par défaut. N'importe quel nombre positif fait l'affaire.

Il est maintenant possible de changer cette valeur à l'initialisation de la librairie.

Exemple :
```
const options = {
  alpha: 1,9
}
const classifier = bayes(options)
```