### PR TITLE
checked if tokens belong to vocabulary before estimate probabilities 🦎

### DIFF
--- a/lib/classificator.js
+++ b/lib/classificator.js
@@ -305,14 +305,16 @@ Naivebayes.prototype.categorize = function(text){
 
     //now determine P( w | c ) for each word `w` in the text
     Object.keys(frequencyTable).forEach(token => {
-      let termFrequencyInText = frequencyTable[token];
-      let tokenProbability = this.tokenProbability(token, category);
+      if (this.vocabulary[token] && this.vocabulary[token] > 0) {
+        let termFrequencyInText = frequencyTable[token];
+        let tokenProbability = this.tokenProbability(token, category);
 
-      // determine the log of the P( w | c ) for this word
-      // logLikelihood += termFrequencyInText * Math.log(tokenProbability);
-      let logTokenProbability = Decimal(tokenProbability);
-      logTokenProbability = logTokenProbability.naturalLogarithm();
-      logLikelihood = logLikelihood.plus(termFrequencyInText * logTokenProbability)
+        // determine the log of the P( w | c ) for this word
+        // logLikelihood += termFrequencyInText * Math.log(tokenProbability);
+        let logTokenProbability = Decimal(tokenProbability);
+        logTokenProbability = logTokenProbability.naturalLogarithm();
+        logLikelihood = logLikelihood.plus(termFrequencyInText * logTokenProbability)
+    }
     });
 
     if (logLikelihood == Number.NEGATIVE_INFINITY) {

--- a/lib/classificator.js
+++ b/lib/classificator.js
@@ -314,7 +314,7 @@ Naivebayes.prototype.categorize = function(text){
         let logTokenProbability = Decimal(tokenProbability);
         logTokenProbability = logTokenProbability.naturalLogarithm();
         logLikelihood = logLikelihood.plus(termFrequencyInText * logTokenProbability)
-    }
+      }
     });
 
     if (logLikelihood == Number.NEGATIVE_INFINITY) {


### PR DESCRIPTION
During categorization, I added a test on each token to check if it belongs to the vocabulary or not. If it is not the case, we should not return a marginal P(w | c) for it. 
This is the behaviour of `MultinomialNB` class of the SciKitLearn library 