### PR TITLE
fix: Get default export from decimal.js

### DIFF
--- a/lib/classificator.js
+++ b/lib/classificator.js
@@ -1,4 +1,4 @@
-const Decimal = require('decimal.js'); // handles arbitrary-precision arithmetics.
+const Decimal = require('decimal.js').default; // handles arbitrary-precision arithmetics.
 
 /*
     Expose our naive-bayes generator function


### PR DESCRIPTION
decimal.js uses ES6 default export statement. Since we are using CommonJS' `require`, we need to pick the `.default` property by hand, or we get a `Decimal is not a function` error.