### PR TITLE
feat: Added an option to use a uniform prior

### DIFF
--- a/lib/classificator.js
+++ b/lib/classificator.js
@@ -20,6 +20,7 @@ const STATE_KEYS = (module.exports.STATE_KEYS = [
   'options',
 ]);
 const DEFAULT_ALPHA = 1
+const DEFAULT_FIT_PRIOR = true
 
 /**
  * Initializes a NaiveBayes instance from a JSON state representation.
@@ -107,7 +108,7 @@ function Naivebayes(options) {
 
   this.tokenizer = this.options.tokenizer || defaultTokenizer;
   this.alpha = this.options.alpha || DEFAULT_ALPHA
-
+  this.fitPrior = this.options.fitPrior === undefined ? DEFAULT_FIT_PRIOR : this.options.fitPrior
   //initialize our vocabulary and its size
   this.vocabulary = {};
   this.vocabularySize = 0;
@@ -295,7 +296,12 @@ Naivebayes.prototype.categorize = function(text){
     //start by calculating the overall probability of this category
     //=>  out of all documents we've ever looked at, how many were
     //    mapped to this category
-    let categoryLikelihood = this.docCount[category] / this.totalDocuments;
+    let categoryLikelihood
+    if (this.fitPrior) {
+      categoryLikelihood = this.docCount[category] / this.totalDocuments;
+    } else {
+      categoryLikelihood = 1
+    }
 
     //take the log to avoid underflow
     // let logLikelihood = Math.log(categoryLikelihood);

--- a/test/classificator.js
+++ b/test/classificator.js
@@ -152,5 +152,39 @@ describe('bayes .learn() correctness', function () {
 
     done()
   })
+
+  it('correctly computes probabilities without prior', function (done) {
+    var classifier = bayes({ fitPrior: false})
+
+    // learn on a very unbalanced dataset
+    classifier.learn('aa', '1')
+    classifier.learn('aa', '1')
+    classifier.learn('aa', '1')
+    classifier.learn('bb', '2')
+
+    // test the likelihoods obtained on test strings
+    assert.equal(classifier.categorize('cc').likelihoods[0].proba, 0.5)
+    assert.equal(Number(classifier.categorize('bb').likelihoods[0].proba).toFixed(6), Number(0.76923077).toFixed(6))
+    assert.equal(Number(classifier.categorize('aa').likelihoods[0].proba).toFixed(6), Number(0.70588235).toFixed(6))
+
+    done()
+  })
+
+  it('correctly computes probabilities with prior', function (done) {
+    var classifier = bayes()
+
+    // learn on a very unbalanced dataset
+    classifier.learn('aa', '1')
+    classifier.learn('aa', '1')
+    classifier.learn('aa', '1')
+    classifier.learn('bb', '2')
+
+    // test the likelihoods obtained on test strings
+    assert.equal(classifier.categorize('cc').likelihoods[0].proba, 0.75)
+    assert.equal(Number(classifier.categorize('bb').likelihoods[0].proba).toFixed(6), Number(0.52631579).toFixed(6))
+    assert.equal(Number(classifier.categorize('aa').likelihoods[0].proba).toFixed(6), Number(0.87804878).toFixed(6))
+
+    done()
+  })
 })
 


### PR DESCRIPTION
In some case, it is preferable not to fit the bayesian prior probability of having a given category. In that case we rather use a uniform prior.