### PR TITLE
Default STATE_KEYS undefined check, fix for no documents

### DIFF
--- a/lib/classificator.js
+++ b/lib/classificator.js
@@ -55,7 +55,7 @@ module.exports.fromJson = (jsonStrOrObject) => {
 
   // override the classifier's state
   STATE_KEYS.forEach((k) => {
-    if (!parameters[k]) {
+    if (typeof parameters[k] === 'undefined') {
       throw new Error(
         `Naivebayes.fromJson: JSON string is missing an expected property: [${k}].`
       );


### PR DESCRIPTION
Changed from:

`if (!parameters[k]) {`

to

`if (typeof parameters[k] === 'undefined') {`

Fix for when `"totalDocuments":0` or `"vocabularySize":0`